### PR TITLE
Archive template: Update to match designs

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -9,6 +9,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_filter( 'render_block_core/pattern', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
 add_filter( 'the_content', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );
 
 /**
  * Enqueue scripts and styles.
@@ -49,4 +50,23 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 
 	$breadcrumbs[0]['title'] = __( 'Documentation', 'wporg-docs' );
 	return $breadcrumbs;
+}
+
+/**
+ * Filter the default query.
+ *
+ * Used to render posts on archive pages (query.inherit = true).
+ *
+ * @param \WP_Query $query The WordPress Query object.
+ */
+function pre_get_posts( $query ) {
+	if ( is_admin() || ! $query->is_main_query() ) {
+		return;
+	}
+
+	// Show many articles on the archive pages.
+	if ( ! $query->is_singular() ) {
+		$query->set( 'posts_per_page', 50 );
+		$query->set( 'orderby', 'menu_order post_title' );
+	}
 }

--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -3,6 +3,21 @@
  * templates or theme.json settings.
  */
 
+// Locally override this value to create a fixed breakpoint, rather than the
+// scaling effect from `clamp(…)`.
+// @todo Maybe move this to the parent theme, if this behavior is preferred.
+body[class] {
+	--wp--preset--spacing--60: 20px;
+}
+
+@media (min-width: 890px) {
+
+	// When larger than 890px, this should snap to 80px.
+	body[class] {
+		--wp--preset--spacing--60: 80px;
+	}
+}
+
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 	--wp--custom--button--hover--color--text: var(--wp--preset--color--charcoal-1);
 	--wp--custom--button--hover--color--background: var(--wp--preset--color--light-grey-2);
@@ -28,6 +43,15 @@
 			fill: inherit;
 		}
 	}
+}
+
+// Update border color in secondary search style, this site uses a light grey.
+.wp-block-search.is-style-secondary-search-control {
+	--local--border-color: var(--wp--preset--color--light-grey-1);
+}
+
+.wp-block-term-description p {
+	margin: 0;
 }
 
 .wp-block-wporg-site-breadcrumbs {

--- a/source/wp-content/themes/wporg-documentation-2022/templates/archive.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/archive.html
@@ -2,8 +2,8 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|60","right":"var:preset|spacing|60"}}}} -->
 <main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60)">
-	<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
-	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)">
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50"}}}} -->
+	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--50)">
 		<!-- wp:column {"width":"66.66%"} -->
 		<div class="wp-block-column" style="flex-basis:66.66%">
 			<!-- wp:query-title {"type":"archive","level":2} /-->

--- a/source/wp-content/themes/wporg-documentation-2022/templates/archive.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/archive.html
@@ -1,27 +1,40 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:spacer {"height":"30px"} -->
-<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:columns {"align":"full","className":"is-style-two-column-display"} -->
-<div class="wp-block-columns alignfull is-style-two-column-display">
-	<!-- wp:column {"style":{"spacing":{"blockGap":"16px"}},"className":"is-left-column"} -->
-	<div class="wp-block-column is-left-column">
-		<!-- wp:query-title {"type":"archive", "level":2} /-->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|60","right":"var:preset|spacing|60"}}}} -->
+<main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60)">
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
+	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:column {"width":"66.66%"} -->
+		<div class="wp-block-column" style="flex-basis:66.66%">
+			<!-- wp:query-title {"type":"archive","level":2} /-->
+	
+			<!-- wp:term-description {"style":{"spacing":{"margin":{"top":"8px"}}},"textColor":"charcoal-4"} /-->
+		</div>
+		<!-- /wp:column -->
+		
+		<!-- wp:column {"width":"33.33%"} -->
+		<div class="wp-block-column" style="flex-basis:33.33%">
+			<!-- wp:search {"label":"Search","showLabel":false,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1"} /-->
+		</div>
+		<!-- /wp:column -->
 	</div>
-	<!-- /wp:column -->
+	<!-- /wp:columns -->
 
-	<!-- wp:column -->
-	<div class="wp-block-column">
-		<!-- wp:template-part {"slug":"post-list"} /-->
+	<!-- wp:query {"queryId":1,"query":{"inherit":true},"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+	<div class="wp-block-query alignwide" style="margin-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:post-template -->
+			<!-- wp:post-title {"level":0,"isLink":true,"textColor":"blueberry-1","fontSize":"normal","fontFamily":"inter"} /-->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination -->
+			<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
+		<!-- /wp:query-pagination -->
 	</div>
-	<!-- /wp:column -->
-</div>
-<!-- /wp:columns -->
+	<!-- /wp:query -->
 
-<!-- wp:spacer -->
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+</main>
+<!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-documentation-2022/templates/archive.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/archive.html
@@ -14,7 +14,7 @@
 		
 		<!-- wp:column {"width":"33.33%"} -->
 		<div class="wp-block-column" style="flex-basis:33.33%">
-			<!-- wp:search {"label":"Search","showLabel":false,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1"} /-->
+			<!-- wp:search {"label":"Search","showLabel":false,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1","placeholder":"Search the documentation"} /-->
 		</div>
 		<!-- /wp:column -->
 	</div>


### PR DESCRIPTION
Fixes #2 — Update the template for category archives. Technically this applies to all archives, but only categories are used on this site, and only category archives are safelisted to use the new theme.

This shows a simple list of links to articles, 50 per page (arbitrary number, we can increase or decrease it). If the category has a description, it shows up under the header. Currently no categories have a description, so they'll need to be added. The second row of screenshots shows a category without a description.

Note: the breadcrumbs will need to be updated, but I'll do that in another PR (probably with #4).

### Screenshots

<table>
<thead>
<tr>
    <th>Large</th>
    <th>Medium</th>
    <th>Small</th>
</tr>
</thead>
<tbody>
<tr>
    <td valign="top"><img src="https://user-images.githubusercontent.com/541093/204919395-2dd371dd-a285-4e97-841a-d063dc3c4593.png"></td>
    <td valign="top"><img src="https://user-images.githubusercontent.com/541093/204919397-8c5949c3-3786-493a-8345-8da8b223c10a.png"></td>
    <td valign="top"><img src="https://user-images.githubusercontent.com/541093/204919399-4caf3c00-930b-4fc3-b506-74b789d200b7.png"></td>
</tr>
<tr>
    <td valign="top"><img src="https://user-images.githubusercontent.com/541093/204919065-da36707e-84b1-4461-a6cf-8bec9e78a777.png"></td>
    <td valign="top"><img src="https://user-images.githubusercontent.com/541093/204919067-e9b6dcfa-293c-4752-82cd-a0418077eb44.png"></td>
    <td valign="top"><img src="https://user-images.githubusercontent.com/541093/204919070-2a489189-4a5a-4629-937d-ab3bc76f7770.png"></td>
</tr>
</tbody>
</table>
