### PR TITLE
Single template: Initial pass to match design

### DIFF
--- a/source/wp-content/plugins/support-helphub/inc/handbook-toc/table-of-contents.php
+++ b/source/wp-content/plugins/support-helphub/inc/handbook-toc/table-of-contents.php
@@ -53,7 +53,16 @@ class WPorg_Handbook_TOC {
 	}
 
 	public function load_filters() {
-		if ( is_singular( $this->post_types ) && ! is_embed() && ! is_front_page() ) {
+		$page_supports_toc = is_singular( $this->post_types ) && ! is_embed() && ! is_front_page();
+
+		/**
+		 * Filter whether the table of contents should be injected into the page.
+		 *
+		 * @param bool $page_supports_toc True if the current page supports a table of contents.
+		 */
+		$should_add_toc = apply_filters( 'wporg_handbook_toc_should_add_toc', $page_supports_toc );
+
+		if ( $should_add_toc ) {
 			add_filter( 'the_content', array( $this, 'add_toc' ) );
 		}
 	}

--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -10,6 +10,12 @@ add_filter( 'render_block_core/pattern', __NAMESPACE__ . '\prevent_arrow_emoji',
 add_filter( 'the_content', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );
+add_filter( 'comment_form_defaults', __NAMESPACE__ . '\comment_form_defaults' );
+add_filter( 'comment_form_field_comment', __NAMESPACE__ . '\hide_field_after_submission' );
+add_filter( 'comment_form_submit_field', __NAMESPACE__ . '\hide_field_after_submission' );
+
+// Enforce log in to leave feedback.
+add_filter( 'pre_option_comment_registration', '__return_true' );
 
 // Remove table of contents.
 add_filter( 'wporg_handbook_toc_should_add_toc', '__return_false' );
@@ -72,4 +78,85 @@ function pre_get_posts( $query ) {
 		$query->set( 'posts_per_page', 50 );
 		$query->set( 'orderby', 'menu_order post_title' );
 	}
+}
+
+/**
+ * Check if the current page has the submission parameter.
+ *
+ * This seems to work but I'm not sure where it's set.
+ */
+function has_submitted_comment_form() {
+	return isset( $_GET['feedback_submitted'] ) && $_GET['feedback_submitted'];  // phpcs:ignore
+}
+
+/**
+ * Update the comment form settings.
+ *
+ * @param array $fields The default comment form arguments.
+ *
+ * @return array Returns the modified fields.
+ */
+function comment_form_defaults( $fields ) {
+	$post    = get_post();
+	$post_id = $post->ID;
+
+	$user          = wp_get_current_user();
+	$user_identity = $user->exists() ? $user->display_name : '';
+
+	$str_log_in = sprintf(
+		/* translators: 1: log in link, 2: support forums link. */
+		__( '<a href="%1$s">Log in</a> to submit feedback. If you need suppport with something that wasn&#39;t covered by this article, please post your question in the <a href="%2$s">support forums</a>.', 'wporg-docs' ),
+		esc_url( wp_login_url( apply_filters( 'the_permalink', get_permalink( $post_id ), $post_id ) ) ),
+		esc_url( home_url( '/forums/' ) )
+	);
+	$fields['must_log_in'] = '<p class="must-log-in">' . $str_log_in . '</p>';
+
+	$fields['title_reply_before'] = '<h2 id="reply-title" class="comment-reply-title has-heading-3-font-size" style="margin-top:0">';
+	$fields['title_reply_after']  = '</h2>';
+	$fields['title_reply']        = __( 'Was this article helpful? How could it be improved?', 'wporg-docs' );
+	if ( has_submitted_comment_form() ) {
+		$fields['title_reply'] = __( 'Thank you for your feedback!', 'wporg-docs' );
+	}
+
+	$fields['label_submit'] = __( 'Submit feedback', 'wporg-docs' );
+
+	$fields['logged_in_as']  = '<p>';
+	$fields['logged_in_as'] .= __( 'Feedback you send to us will go only to the folks who maintain documentation. They may reach out in case there are questions or would like to followup feedback. But that too will stay behind the scenes.', 'wporg-docs' );
+	$fields['logged_in_as'] .= '</p></p>';
+	$fields['logged_in_as'] .= sprintf(
+		/* translators: %s: support forums link. */
+		__( 'This is not for personalized support. Please create a <a href="%s">forum thread</a> instead to receive help from the community.', 'wporg-docs' ),
+		esc_url( home_url( '/forums/' ) )
+	);
+	$fields['logged_in_as'] .= '</p>';
+
+	$fields['comment_notes_after']  = '<p class="logged-in-as">';
+	$fields['comment_notes_after'] .= sprintf(
+		/* translators: 1: User name, 2: Logout URL. */
+		__( 'Logged in as %1$s (<a href="%2$s">log out?</a>)', 'wporg-docs' ),
+		$user_identity,
+		wp_logout_url( apply_filters( 'the_permalink', get_permalink( $post_id ), $post_id ) )
+	);
+	$fields['comment_notes_after'] .= '</p>';
+
+	if ( has_submitted_comment_form() ) {
+		$fields['logged_in_as']        = '<p>' . __( 'We will review it as quickly as possible.', 'wporg-docs' ) . '</p>';
+		$fields['comment_notes_after'] = '';
+	}
+
+	return $fields;
+}
+
+/**
+ * Remove the field if the form has been submitted.
+ *
+ * @param string $field The HTML-formatted output of the comment form field.
+ *
+ * @return string Empty string or initial field.
+ */
+function hide_field_after_submission( $field ) {
+	if ( has_submitted_comment_form() ) {
+		return '';
+	}
+	return $field;
 }

--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -11,6 +11,9 @@ add_filter( 'the_content', __NAMESPACE__ . '\prevent_arrow_emoji', 20 );
 add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\set_site_breadcrumbs' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\pre_get_posts' );
 
+// Remove table of contents.
+add_filter( 'wporg_handbook_toc_should_add_toc', '__return_false' );
+
 /**
  * Enqueue scripts and styles.
  */

--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -22,6 +22,19 @@ p.has-background {
 	padding: var(--wp--preset--spacing--20);
 }
 
+// Slot the search & table of contents into a floating sidebar on large screens.
+@media (min-width: 1280px) {
+	.sidebar-container {
+		position: absolute;
+		// 57px is height of the sticky bar.
+		top: calc(var(--wp-global-header-offset, 0px) + 57px);
+		left: calc(var(--wp--style--global--content-size) + var(--wp--preset--spacing--60) + var(--wp--preset--spacing--80));
+		right: var(--wp--preset--spacing--60);
+		margin-top: var(--wp--preset--spacing--40) !important;
+		max-width: var(--wp--style--global--content-size);
+	}
+}
+
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 	--wp--custom--button--hover--color--text: var(--wp--preset--color--charcoal-1);
 	--wp--custom--button--hover--color--background: var(--wp--preset--color--light-grey-2);

--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -28,7 +28,10 @@ p.has-background {
 		position: absolute;
 		// 57px is height of the sticky bar.
 		top: calc(var(--wp-global-header-offset, 0px) + 57px);
-		left: calc(var(--wp--style--global--content-size) + var(--wp--preset--spacing--60) + var(--wp--preset--spacing--80));
+		// Total = left edge spacing, content width, space between content & sidebar.
+		// stylelint-disable-next-line max-line-length
+		left: calc(var(--wp--preset--spacing--80) + var(--wp--style--global--content-size) + var(--wp--preset--spacing--60));
+		// Total = right edge spacing.
 		right: var(--wp--preset--spacing--60);
 		margin-top: var(--wp--preset--spacing--40) !important;
 		max-width: var(--wp--style--global--content-size);

--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -18,6 +18,10 @@ body[class] {
 	}
 }
 
+p.has-background {
+	padding: var(--wp--preset--spacing--20);
+}
+
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 	--wp--custom--button--hover--color--text: var(--wp--preset--color--charcoal-1);
 	--wp--custom--button--hover--color--background: var(--wp--preset--color--light-grey-2);

--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -1,18 +1,55 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"tagName":"main"} -->
-<main class="wp-block-group">
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained","justifyContent":"left"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|60","right":"var:preset|spacing|60"}}}} -->
+<main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60)">
 
-<!-- wp:group {"tagName":"article","layout":{"inherit":true}} -->
-<article class="wp-block-group">
-	<!-- wp:group {"tagName":"header","layout":{"inherit":true},"align":"full"} -->
-	<header class="wp-block-group alignfull"><!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} /--></header>
+	<!-- wp:group {"tagName":"article"} -->
+	<article class="wp-block-group">
+		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} /-->
+
+		<!-- wp:search {"label":"Search","showLabel":false,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1","placeholder":"Search the documentation"} /-->
+
+		<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|10","right":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|10"}}},"backgroundColor":"blueberry-4","textColor":"charcoal-1","layout":{"type":"constrained"}} -->
+		<div class="wp-block-group has-charcoal-1-color has-blueberry-4-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--10)">
+			<!-- wp:paragraph -->
+			<p>Table of contents.</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:post-content {"layout":{"inherit":true}} /-->
+	</article>
 	<!-- /wp:group -->
 
-	<!-- wp:post-content {"layout":{"inherit":true},"align":"full"} /-->
-</article>
-<!-- /wp:group -->
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}} -->
+	<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+		<!-- wp:post-comments-form /-->
+	</div>
+	<!-- /wp:group -->
 
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|50"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+	<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group">
+			<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+			<p style="font-style:normal;font-weight:700">First published</p>
+			<!-- /wp:paragraph -->
+	
+			<!-- wp:post-date {"fontSize":"normal"} /-->
+		</div>
+		<!-- /wp:group -->
+	
+		<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group">
+			<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+			<p style="font-style:normal;font-weight:700">Last updated</p>
+			<!-- /wp:paragraph -->
+	
+			<!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
 </main>
 <!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -7,14 +7,21 @@
 	<article class="wp-block-group">
 		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} /-->
 
-		<!-- wp:search {"label":"Search","showLabel":false,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1","placeholder":"Search the documentation"} /-->
+		<!-- wp:group {"tagName":"aside","className":"sidebar-container"} -->
+		<aside class="wp-block-group sidebar-container">
+			<!-- wp:search {"label":"Search","showLabel":false,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1","placeholder":"Search the documentation"} /-->
 
-		<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|10","right":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|10"}}},"backgroundColor":"blueberry-4","textColor":"charcoal-1","layout":{"type":"constrained"}} -->
-		<div class="wp-block-group has-charcoal-1-color has-blueberry-4-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--10)">
+			<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"charcoal-1","layout":{"type":"constrained"}} -->
+			<div class="wp-block-group has-charcoal-1-color has-blueberry-4-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)">
+				<!-- wp:paragraph -->
+				<p>Table of contents.</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
 			<!-- wp:paragraph -->
-			<p>Table of contents.</p>
+			<p><a href="#wp--skip-link--target">↑ Back to top</a></p>
 			<!-- /wp:paragraph -->
-		</div>
+		</aside>
 		<!-- /wp:group -->
 
 		<!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/source/wp-content/themes/wporg-documentation-2022/theme.json
+++ b/source/wp-content/themes/wporg-documentation-2022/theme.json
@@ -4,6 +4,39 @@
 	"settings": {},
 	"styles": {
 		"blocks": {
+			"core/preformatted": {
+				"border": {
+					"color": "var(--wp--preset--color--light-grey-1)",
+					"radius": "2px",
+					"style": "solid",
+					"width": "1px"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--light-grey-2)",
+					"text": "var(--wp--preset--color--charcoal-1)"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--monospace)"
+				},
+				"spacing": {
+					"padding": "var(--wp--preset--spacing--20)"
+				}
+			},
+			"core/code": {
+				"border": {
+					"color": "var(--wp--preset--color--light-grey-1)",
+					"radius": "2px",
+					"style": "solid",
+					"width": "1px"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--light-grey-2)",
+					"text": "var(--wp--preset--color--charcoal-1)"
+				},
+				"spacing": {
+					"padding": "var(--wp--preset--spacing--20)"
+				}
+			},
 			"core/table": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"

--- a/source/wp-content/themes/wporg-documentation-2022/theme.json
+++ b/source/wp-content/themes/wporg-documentation-2022/theme.json
@@ -1,5 +1,14 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
-	"settings": {}
+	"settings": {},
+	"styles": {
+		"blocks": {
+			"core/table": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)"
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fixes #3, fixes #5. This roughs in the single template and custom comment form.

### Screenshots

![Screen Shot 2022-12-02 at 15 29 46-fullpage](https://user-images.githubusercontent.com/541093/205380636-b385eec6-8044-43c2-8ddd-61ae81dc0a84.png)

At 1280px, the search & ToC jump into a right sidebar. Eventually this could scroll with the content, if the viewport is tall enough? But currently it's fixed to the top of the page.

![Screen Shot 2022-12-02 at 15 29 00-fullpage](https://user-images.githubusercontent.com/541093/205380629-a44501ef-2bb9-4372-900a-7d474417fffa.png)

Logged out comment form:

![Screen Shot 2022-12-02 at 15 30 23](https://user-images.githubusercontent.com/541093/205380640-a70e8389-ec4a-4ec1-8f23-858b7eff325a.png)

