### PR TITLE
Add Dynamic Table of Contents block

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -2,6 +2,9 @@
 
 namespace WordPressdotorg\Theme\Documentation_2022;
 
+// Block files
+require_once __DIR__ . '/src/table-of-contents/index.php';
+
 /**
  * Actions and filters.
  */

--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -36,6 +36,10 @@ p.has-background {
 		right: var(--wp--preset--spacing--60);
 		margin-top: var(--wp--preset--spacing--40) !important;
 		max-width: calc(var(--wp--style--global--wide-size) - var(--wp--style--global--content-size));
+
+		&.is-fixed-sidebar {
+			position: fixed;
+		}
 	}
 }
 

--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -3,11 +3,13 @@
  * templates or theme.json settings.
  */
 
-// Locally override this value to create a fixed breakpoint, rather than the
-// scaling effect from `clamp(…)`.
-// @todo Maybe move this to the parent theme, if this behavior is preferred.
 body[class] {
+	// Locally override this value to create a fixed breakpoint, rather than the
+	// scaling effect from `clamp(…)`.
+	// @todo Maybe move this to the parent theme, if this behavior is preferred.
 	--wp--preset--spacing--60: 20px;
+	// Height of the local header (breadcrumbs & subnav).
+	--wp-local-header-offset: 57px;
 }
 
 @media (min-width: 890px) {
@@ -26,15 +28,14 @@ p.has-background {
 @media (min-width: 1280px) {
 	.sidebar-container {
 		position: absolute;
-		// 57px is height of the sticky bar.
-		top: calc(var(--wp-global-header-offset, 0px) + 57px);
+		top: calc(var(--wp-global-header-offset, 0px) + var(--wp-local-header-offset, 0px));
 		// Total = left edge spacing, content width, space between content & sidebar.
 		// stylelint-disable-next-line max-line-length
 		left: calc(var(--wp--preset--spacing--80) + var(--wp--style--global--content-size) + var(--wp--preset--spacing--60));
 		// Total = right edge spacing.
 		right: var(--wp--preset--spacing--60);
 		margin-top: var(--wp--preset--spacing--40) !important;
-		max-width: var(--wp--style--global--content-size);
+		max-width: calc(var(--wp--style--global--wide-size) - var(--wp--style--global--content-size));
 	}
 }
 

--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -24,6 +24,10 @@ p.has-background {
 	padding: var(--wp--preset--spacing--20);
 }
 
+.sidebar-container .is-link-to-top {
+	display: none;
+}
+
 // Slot the search & table of contents into a floating sidebar on large screens.
 @media (min-width: 1280px) {
 	.sidebar-container {
@@ -39,6 +43,10 @@ p.has-background {
 
 		&.is-fixed-sidebar {
 			position: fixed;
+
+			.is-link-to-top {
+				display: block;
+			}
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/block.json
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/block.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/table-of-contents",
+	"title": "Dynamic Table of Contents",
+	"category": "layout",
+	"description": "A dynamic list of headings in the current page.",
+	"keywords": [ "document outline", "summary" ],
+	"textdomain": "wporg",
+	"attributes": {},
+	"supports": {
+		"html": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"gradients": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": false
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/block.json
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/block.json
@@ -18,7 +18,7 @@
 		},
 		"spacing": {
 			"margin": true,
-			"padding": false
+			"padding": true
 		},
 		"typography": {
 			"fontSize": true,
@@ -26,5 +26,6 @@
 		}
 	},
 	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js",
 	"style": "file:./style-index.css"
 }

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/block.json
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/block.json
@@ -13,7 +13,6 @@
 		"color": {
 			"text": true,
 			"background": true,
-			"gradients": true,
 			"link": true
 		},
 		"spacing": {

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/index.js
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+function Edit() {
+	return <div { ...useBlockProps() }>Table of contents</div>;
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/index.php
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/index.php
@@ -71,7 +71,8 @@ function render( $attributes, $content, $block ) {
 		'the_content',
 		function( $content ) use ( $items ) {
 			return inject_ids_into_headings( $content, $items );
-		}
+		},
+		5 // Run early, before special character handling, so the items match.
 	);
 
 	$wrapper_attributes = get_block_wrapper_attributes();

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/index.php
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/index.php
@@ -197,13 +197,12 @@ function inject_ids_into_headings( $content, $items ) {
 		}
 
 		$replacements[] = sprintf(
-			'<%1$s id="%2$s" class="%3$s" tabindex="-1" %4$s>%5$s <a href="#%2$s" title="%6$s"></a></%1$s>',
+			'<%1$s id="%2$s" class="%3$s" tabindex="-1" %4$s><a href="#%2$s">%5$s</a></%1$s>',
 			$tag,
 			$id,
 			$class_name,
 			$extra_attrs,
-			$title,
-			__( 'Link', 'wporg-docs' )
+			$title
 		);
 	}
 

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/index.php
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/index.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Block Name: Dynamic Table of Contents
+ * Description: A dynamic list of headings in the current page.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Documentation_2022\Dynamic_ToC_Block;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/table-of-contents',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	$items = get_headings( get_the_content() );
+	if ( ! $items ) {
+		return '';
+	}
+
+	$content  = '<h2 class="has-charcoal-1-color has-text-color has-inter-font-family has-large-font-size" style="margin-top:0px">';
+	$content .= __( 'In this article', 'wporg-docs' );
+	$content .= '</h2>';
+	$content .= '<ul>';
+
+	$last_item = false;
+
+	foreach ( $items as $item ) {
+		if ( $last_item ) {
+			if ( $last_item < $item['level'] ) {
+				$content .= "\n<ul>\n";
+			} elseif ( $last_item > $item['level'] ) {
+				$content .= "\n</ul></li>\n";
+			} else {
+				$content .= "</li>\n";
+			}
+		}
+
+		$last_item = $item['level'];
+
+		$content .= '<li><a href="#' . esc_attr( $item['id'] ) . '">' . $item['title'] . '</a>';
+	}
+
+	$content .= "</ul>\n";
+
+	// Use the parsed headings & IDs to inject IDs into the post content.
+	add_filter(
+		'the_content',
+		function( $content ) use ( $items ) {
+			return inject_ids_into_headings( $content, $items );
+		}
+	);
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$content
+	);
+}
+
+/**
+ * Get headings from a content string.
+ *
+ * @param string $content The post content.
+ *
+ * @return array A list of heading objects.
+ */
+function get_headings( $content ) {
+	$tag = 'h(?P<level>[1-4])';
+	preg_match_all( "/(?P<tag><{$tag}(?P<attrs>[^>]*)>)(?P<title>.*?)(<\/{$tag}>)/iJ", $content, $matches, PREG_SET_ORDER );
+
+	foreach ( $matches as $i => $item ) {
+		// Set an ID property to prevent warnings later.
+		$matches[ $i ]['id'] = '';
+
+		// Remove heading if there is no plain text.
+		if ( empty( trim( wp_strip_all_tags( $item['title'] ) ) ) ) {
+			unset( $matches[ $i ] );
+		}
+	}
+
+	if ( count( $matches ) < 2 ) {
+		return array();
+	}
+
+	$reserved_ids = (array) apply_filters(
+		'handbooks_reserved_ids',
+		array(
+			'main',
+			'masthead',
+			'menu-header',
+			'page',
+			'primary',
+			'secondary',
+			'secondary-content',
+			'site-navigation',
+			'wordpress-org',
+			'wp-toolbar',
+			'wpadminbar',
+			'wporg-footer',
+			'wporg-header',
+		)
+	);
+
+	// Generate IDs for the headings.
+	foreach ( $matches as $i => $item ) {
+		$used_ids            = array_filter( wp_list_pluck( $matches, 'id' ) );
+		$matches[ $i ]['id'] = get_id_for_item( $item, array_merge( $reserved_ids, $used_ids ) );
+	}
+
+	return $matches;
+}
+
+/**
+ * Generate an ID for a given HTML element, use the tags `id` attribute if set.
+ *
+ * @param array    $item     A single heading item.
+ * @param string[] $used_ids The list of existing IDs plus reserved IDs.
+ *
+ * @return string A unique ID.
+ */
+function get_id_for_item( $item, $used_ids ) {
+	if ( ! empty( $item['id'] ) ) {
+		return $item['id'];
+	}
+
+	// Check to see if the item already had a non-empty ID, else generate one from the title.
+	if ( preg_match( '/id=(["\'])(?P<id>[^"\']+)\\1/', $item['attrs'], $m ) ) {
+		$id = $m['id'];
+	} else {
+		$id = sanitize_title( $item['title'] );
+	}
+
+	// Append unique suffix if anchor ID isn't unique in the document.
+	$count   = 2;
+	$orig_id = $id;
+	while ( in_array( $id, $used_ids, true ) && $count < 50 ) {
+		$id = $orig_id . '-' . $count;
+		$count++;
+	}
+
+	return $id;
+}
+
+/**
+ * Replace the headings in a content string with headings including the ID attribute.
+ *
+ * @param string $content The post content.
+ * @param array  $items   The headings as parsed from the content, plus unique IDs.
+ */
+function inject_ids_into_headings( $content, $items ) {
+	$matches      = [];
+	$replacements = [];
+
+	foreach ( $items as $item ) {
+		$matches[]   = $item[0];
+		$tag         = 'h' . $item['level'];
+		$id          = $item['id'];
+		$title       = $item['title'];
+		$extra_attrs = $item['attrs'];
+		$class_name  = 'is-toc-heading';
+
+		if ( $extra_attrs ) {
+			// Strip all IDs from the heading attributes (including empty), we'll replace it with one below.
+			$extra_attrs = trim( preg_replace( '/id=(["\'])[^"\']*\\1/i', '', $extra_attrs ) );
+
+			// Extract any classes present, we're adding our own attribute.
+			if ( preg_match( '/class=(["\'])(?P<class>[^"\']+)\\1/i', $extra_attrs, $m ) ) {
+				$extra_attrs = str_replace( $m[0], '', $extra_attrs );
+				$class_name .= ' ' . $m['class'];
+			}
+		}
+
+		$replacements[] = sprintf(
+			'<%1$s id="%2$s" class="%3$s" tabindex="-1" %4$s>%5$s <a href="#%2$s" title="%6$s"></a></%1$s>',
+			$tag,
+			$id,
+			$class_name,
+			$extra_attrs,
+			$title,
+			__( 'Link', 'wporg-docs' )
+		);
+	}
+
+	if ( $replacements ) {
+		if ( count( array_unique( $matches ) ) !== count( $matches ) ) {
+			foreach ( $matches as $i => $match ) {
+				$content = preg_replace( '/' . preg_quote( $match, '/' ) . '/', $replacements[ $i ], $content, 1 );
+			}
+		} else {
+			$content = str_replace( $matches, $replacements, $content );
+		}
+	}
+
+	return $content;
+}

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/style.scss
@@ -1,3 +1,4 @@
+// stylelint-disable-next-line selector-id-pattern
 #wp--skip-link--target {
 	scroll-margin-top: var(--wp-local-header-offset, 0);
 }
@@ -12,6 +13,7 @@
 		height: 24px;
 		text-decoration: none !important;
 		vertical-align: baseline;
+
 		// stylelint-disable-next-line function-url-quotes
 		background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.083 17.639H8.444a5.194 5.194 0 1 1 0-10.389H10.084v1.5H8.443a3.694 3.694 0 0 0 0 7.389H10.084v1.5ZM13.917 7.25h1.639a5.194 5.194 0 0 1 0 10.39H13.915v-1.5H15.557a3.694 3.694 0 0 0 0-7.39H13.915v-1.5Zm-4.584 6.084h5.334v-1.5H9.333v1.5Z' fill='%233858E9'/%3E%3C/svg%3E%0A");
 	}

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/style.scss
@@ -1,15 +1,15 @@
-// stylelint-disable-next-line selector-id-pattern
-#wp--skip-link--target {
-	@media (min-width: 890px) {
+@media (min-width: 890px) {
+	// stylelint-disable-next-line selector-id-pattern
+	#wp--skip-link--target {
+		scroll-margin-top: var(--wp-local-header-offset, 0);
+	}
+
+	.is-toc-heading {
 		scroll-margin-top: var(--wp-local-header-offset, 0);
 	}
 }
 
 .is-toc-heading {
-	@media (min-width: 890px) {
-		scroll-margin-top: var(--wp-local-header-offset, 0);
-	}
-
 	a {
 		$icon-size: 24px;
 		color: inherit;
@@ -17,7 +17,7 @@
 		padding-right: calc(#{$icon-size} + 0.1em);
 
 		&::after {
-			content: '';
+			content: "";
 			display: inline-block;
 			opacity: 0;
 			margin-right: calc(#{$icon-size * -1} - 0.1em);
@@ -38,10 +38,11 @@
 	a:focus::after,
 	a:hover::after {
 		opacity: 1;
-	}	
+	}
 
 	&:focus,
 	&:focus-visible {
 		outline: none;
+		border-left: 3px solid var(--wp--preset--color--blueberry-1);
 	}
 }

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/style.scss
@@ -1,10 +1,14 @@
 // stylelint-disable-next-line selector-id-pattern
 #wp--skip-link--target {
-	scroll-margin-top: var(--wp-local-header-offset, 0);
+	@media (min-width: 890px) {
+		scroll-margin-top: var(--wp-local-header-offset, 0);
+	}
 }
 
 .is-toc-heading {
-	scroll-margin-top: var(--wp-local-header-offset, 0);
+	@media (min-width: 890px) {
+		scroll-margin-top: var(--wp-local-header-offset, 0);
+	}
 
 	a {
 		display: inline-block;

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/style.scss
@@ -1,0 +1,29 @@
+#wp--skip-link--target {
+	scroll-margin-top: var(--wp-local-header-offset, 0);
+}
+
+.is-toc-heading {
+	scroll-margin-top: var(--wp-local-header-offset, 0);
+
+	a {
+		display: inline-block;
+		opacity: 0;
+		width: 24px;
+		height: 24px;
+		text-decoration: none !important;
+		vertical-align: baseline;
+		// stylelint-disable-next-line function-url-quotes
+		background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.083 17.639H8.444a5.194 5.194 0 1 1 0-10.389H10.084v1.5H8.443a3.694 3.694 0 0 0 0 7.389H10.084v1.5ZM13.917 7.25h1.639a5.194 5.194 0 0 1 0 10.39H13.915v-1.5H15.557a3.694 3.694 0 0 0 0-7.39H13.915v-1.5Zm-4.584 6.084h5.334v-1.5H9.333v1.5Z' fill='%233858E9'/%3E%3C/svg%3E%0A");
+	}
+
+	&:hover a,
+	&:focus a,
+	a:focus {
+		opacity: 1;
+	}
+
+	&:focus,
+	&:focus-visible {
+		outline: none;
+	}
+}

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/style.scss
@@ -11,22 +11,34 @@
 	}
 
 	a {
-		display: inline-block;
-		opacity: 0;
-		width: 24px;
-		height: 24px;
+		$icon-size: 24px;
+		color: inherit;
 		text-decoration: none !important;
-		vertical-align: baseline;
+		padding-right: calc(#{$icon-size} + 0.1em);
 
-		// stylelint-disable-next-line function-url-quotes
-		background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.083 17.639H8.444a5.194 5.194 0 1 1 0-10.389H10.084v1.5H8.443a3.694 3.694 0 0 0 0 7.389H10.084v1.5ZM13.917 7.25h1.639a5.194 5.194 0 0 1 0 10.39H13.915v-1.5H15.557a3.694 3.694 0 0 0 0-7.39H13.915v-1.5Zm-4.584 6.084h5.334v-1.5H9.333v1.5Z' fill='%233858E9'/%3E%3C/svg%3E%0A");
+		&::after {
+			content: '';
+			display: inline-block;
+			opacity: 0;
+			margin-right: calc(#{$icon-size * -1} - 0.1em);
+			width: calc(#{$icon-size} + 0.1em);
+			height: $icon-size;
+			text-decoration: none !important;
+			vertical-align: baseline;
+
+			// stylelint-disable-next-line function-url-quotes
+			background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.083 17.639H8.444a5.194 5.194 0 1 1 0-10.389H10.084v1.5H8.443a3.694 3.694 0 0 0 0 7.389H10.084v1.5ZM13.917 7.25h1.639a5.194 5.194 0 0 1 0 10.39H13.915v-1.5H15.557a3.694 3.694 0 0 0 0-7.39H13.915v-1.5Zm-4.584 6.084h5.334v-1.5H9.333v1.5Z' fill='%233858E9'/%3E%3C/svg%3E%0A");
+			background-position: right center;
+			background-repeat: no-repeat;
+			background-size: contain;
+		}
 	}
 
-	&:hover a,
-	&:focus a,
-	a:focus {
+	&:focus a::after,
+	a:focus::after,
+	a:hover::after {
 		opacity: 1;
-	}
+	}	
 
 	&:focus,
 	&:focus-visible {

--- a/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/view.js
+++ b/source/wp-content/themes/wporg-documentation-2022/src/table-of-contents/view.js
@@ -1,0 +1,17 @@
+const init = () => {
+	const containers = document.querySelectorAll( '.wp-block-wporg-table-of-contents' );
+
+	if ( containers ) {
+		containers.forEach( ( element ) => {
+			// 200 is an estimate for the fixed header height + top margin.
+			const viewHeight = window.innerHeight - 200;
+			// If the table of contents sidebar is shorter than the view area, apply the
+			// class so that it's fixed and scrolls with the page content.
+			if ( element.parentNode?.offsetHeight < viewHeight ) {
+				element.parentNode.classList.add( 'is-fixed-sidebar' );
+			}
+		} );
+	}
+};
+
+window.addEventListener( 'load', init );

--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -13,9 +13,7 @@
 
 			<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"charcoal-1","layout":{"type":"constrained"}} -->
 			<div class="wp-block-group has-charcoal-1-color has-blueberry-4-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)">
-				<!-- wp:paragraph -->
-				<p>Table of contents.</p>
-				<!-- /wp:paragraph -->
+				<!-- wp:wporg/table-of-contents /-->
 			</div>
 			<!-- /wp:group -->
 			<!-- wp:paragraph {"fontSize":"small"} -->

--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -13,8 +13,8 @@
 
 			<!-- wp:wporg/table-of-contents {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"charcoal-1"} /-->
 
-			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size"><a href="#wp--skip-link--target">↑ Back to top</a></p>
+			<!-- wp:paragraph {"fontSize":"small","className":"is-link-to-top"} -->
+			<p class="has-small-font-size is-link-to-top"><a href="#wp--skip-link--target">↑ Back to top</a></p>
 			<!-- /wp:paragraph -->
 		</aside>
 		<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -11,11 +11,8 @@
 		<aside class="wp-block-group sidebar-container">
 			<!-- wp:search {"label":"Search","showLabel":false,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","borderColor":"light-grey-1","placeholder":"Search the documentation"} /-->
 
-			<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"charcoal-1","layout":{"type":"constrained"}} -->
-			<div class="wp-block-group has-charcoal-1-color has-blueberry-4-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)">
-				<!-- wp:wporg/table-of-contents /-->
-			</div>
-			<!-- /wp:group -->
+			<!-- wp:wporg/table-of-contents {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"charcoal-1"} /-->
+
 			<!-- wp:paragraph {"fontSize":"small"} -->
 			<p class="has-small-font-size"><a href="#wp--skip-link--target">↑ Back to top</a></p>
 			<!-- /wp:paragraph -->

--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -18,8 +18,8 @@
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->
-			<!-- wp:paragraph -->
-			<p><a href="#wp--skip-link--target">↑ Back to top</a></p>
+			<!-- wp:paragraph {"fontSize":"small"} -->
+			<p class="has-small-font-size"><a href="#wp--skip-link--target">↑ Back to top</a></p>
 			<!-- /wp:paragraph -->
 		</aside>
 		<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-documentation-2022/theme.json
+++ b/source/wp-content/themes/wporg-documentation-2022/theme.json
@@ -41,6 +41,11 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--normal)"
 				}
+			},
+			"wporg/table-of-contents": {
+				"color": {
+					"text": "var(--wp--preset--color--blueberry-1)"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #7, fixes #9 — This adds a "Dynamic Table of Contents" block. Most of the code for pulling out the headings comes from [the current ToC code](https://github.com/WordPress/wporg-documentation-2022/blob/trunk/source/wp-content/plugins/support-helphub/inc/handbook-toc/table-of-contents.php), but given the way it's currently written, I can't use it directly. I decided to copy over the code here since it's already proven functional on the current site & handbooks.

If this looks good, we can move this block to mu-plugins in the future.

### Screenshots

A long table of contents stays at the top of the page so it can be scrolled.
![desktop-long-toc](https://user-images.githubusercontent.com/541093/205411697-810bf53b-98bb-4187-b6e9-56e442ee7bfd.png)

If the table of contents is short enough to fit in the viewport, it's fixed to the screen and scrolls with you.
![desktop-short-toc](https://user-images.githubusercontent.com/541093/205411700-57d659bd-a4c5-460d-9a89-635388228ac0.png)

Headings, when hovered, have the link icon.
![hovered-heading](https://user-images.githubusercontent.com/541093/205411701-bd1526f8-f239-4d30-b851-9ce24a5e4b59.png)

On medium & small screens (<1280px) the table of contents stays inline with the content. 

![med-toc](https://user-images.githubusercontent.com/541093/205411887-205851e8-c37a-42c4-b595-e8f528429623.png)

![mobile-toc](https://user-images.githubusercontent.com/541093/205411703-2e3af300-7751-4c59-985f-fb1848cf0121.png)
