### PR TITLE
Enable access to bbPress topic/reply pages that aren't public

### DIFF
--- a/source/wp-content/mu-plugins/site-support.php
+++ b/source/wp-content/mu-plugins/site-support.php
@@ -49,6 +49,11 @@ function should_use_new_theme() {
 		return true;
 	}
 
+	// Some bbPress permalinks use non-pretty links from the site root.
+	if ( '/' === $request_uri && ! empty( $_GET['post_type'] ) && in_array( $_GET['post_type'], [ 'topic', 'reply' ] ) ) {
+		return false;
+	}
+	
 	// A list of specific pages to use the new theme.
 	$new_theme_pages = array(
 		'/',


### PR DESCRIPTION
Some bbPress links that are to non-public resources (Spam or archived threads for example) use the following URL format:
https://wordpress.org/support/?post_type=topic&p=123123123&view=all

Currently, this url attempts to load the new theme, and then throws a white screen. I assume because there's no matching templates.

This PR, which is 100% untested, attempts to work around that.

For testing, this url is to an archived thread which triggers it: https://wordpress.org/support/?post_type=topic&p=16270331&view=all