### PR TITLE
Add category hierarchy to the breadcrumbs

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -55,8 +55,7 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 		if ( $category->category_parent ) {
 			$parent        = get_term( $category->category_parent );
 			$breadcrumbs[] = array(
-				// @todo This should link to the topic landing page.
-				'url'   => get_term_link( $parent->term_id, $parent->taxonomy ),
+				'url'   => get_topic_permalink( $parent ),
 				'title' => $parent->name,
 			);
 		}
@@ -73,8 +72,7 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 			if ( $category->parent ) {
 				$parent        = get_term( $category->parent );
 				$breadcrumbs[] = array(
-					// @todo This should link to the topic landing page.
-					'url'   => get_term_link( $parent->term_id, $parent->taxonomy ),
+					'url'   => get_topic_permalink( $parent ),
 					'title' => $parent->name,
 				);
 			}
@@ -90,6 +88,25 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	}
 
 	return $breadcrumbs;
+}
+
+/**
+ * Get the topic landing page permalink for a given parent category.
+ */
+function get_topic_permalink( $category ) {
+	if ( empty( $category->slug ) ) {
+		return '';
+	}
+	switch ( $category->slug ) {
+		case 'wordpress-overview':
+			return site_url( '/overview/' );
+		case 'technical-guides':
+			return site_url( '/technical-guides/' );
+		case 'support-guides':
+			return site_url( '/support-guides/' );
+		case 'customization':
+			return site_url( '/customization/' );
+	}
 }
 
 /**

--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -46,6 +46,10 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	if ( is_front_page() ) {
 		return array();
 	}
+
+	// Set the first item's title. By default this is the site title, but the
+	// site title for `w.org/support` is "WordPress Forums", which is not
+	// correct for the breadcrumbs.
 	$breadcrumbs[0]['title'] = __( 'Documentation', 'wporg-docs' );
 
 	if ( is_category() ) {

--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -46,8 +46,49 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	if ( is_front_page() ) {
 		return array();
 	}
-
 	$breadcrumbs[0]['title'] = __( 'Documentation', 'wporg-docs' );
+
+	if ( is_category() ) {
+		// Format: home / topic page / category
+		$category    = get_queried_object();
+		$breadcrumbs = array( $breadcrumbs[0] );
+		if ( $category->category_parent ) {
+			$parent        = get_term( $category->category_parent );
+			$breadcrumbs[] = array(
+				// @todo This should link to the topic landing page.
+				'url'   => get_term_link( $parent->term_id, $parent->taxonomy ),
+				'title' => $parent->name,
+			);
+		}
+		$breadcrumbs[] = array(
+			'url'   => '',
+			'title' => $category->name,
+		);
+	} elseif ( is_singular( 'helphub_article' ) ) {
+		// Format: home / topic page / category / article title
+		$breadcrumbs = array( $breadcrumbs[0] );
+		$categories  = get_the_category();
+		if ( $categories ) {
+			$category = $categories[0];
+			if ( $category->parent ) {
+				$parent        = get_term( $category->parent );
+				$breadcrumbs[] = array(
+					// @todo This should link to the topic landing page.
+					'url'   => get_term_link( $parent->term_id, $parent->taxonomy ),
+					'title' => $parent->name,
+				);
+			}
+			$breadcrumbs[] = array(
+				'url'   => get_term_link( $category->term_id, $category->taxonomy ),
+				'title' => $category->name,
+			);
+		}
+		$breadcrumbs[] = array(
+			'url'   => '',
+			'title' => get_the_title(),
+		);
+	}
+
 	return $breadcrumbs;
 }
 

--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -101,16 +101,11 @@ function get_topic_permalink( $category ) {
 	if ( empty( $category->slug ) ) {
 		return '';
 	}
-	switch ( $category->slug ) {
-		case 'wordpress-overview':
-			return site_url( '/overview/' );
-		case 'technical-guides':
-			return site_url( '/technical-guides/' );
-		case 'support-guides':
-			return site_url( '/support-guides/' );
-		case 'customization':
-			return site_url( '/customization/' );
+        if ( 'wordpress-overview' === $category->slug ) {
+	    return site_url( '/overview/' );
 	}
+	
+	return site_url( '/' . $category->slug . '/' );
 }
 
 /**

--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -101,10 +101,11 @@ function get_topic_permalink( $category ) {
 	if ( empty( $category->slug ) ) {
 		return '';
 	}
-        if ( 'wordpress-overview' === $category->slug ) {
-	    return site_url( '/overview/' );
+
+	if ( 'wordpress-overview' === $category->slug ) {
+		return site_url( '/overview/' );
 	}
-	
+
 	return site_url( '/' . $category->slug . '/' );
 }
 

--- a/source/wp-content/themes/wporg-documentation-2022/parts/header.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header.html
@@ -2,8 +2,8 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"16px","left":"var:preset|spacing|60"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"blueberry-1","textColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-sticky has-white-color has-blueberry-1-background-color has-text-color has-background has-link-color" style="padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /--></div>
+<div class="wp-block-group alignfull"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"className":"wporg-site-breadcrumbs-container"} -->
+<div class="wp-block-group wporg-site-breadcrumbs-container"><!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:navigation {"textColor":"white","backgroundColor":"blueberry-1","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} -->

--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -89,6 +89,26 @@ p.has-background {
 
 .wp-block-wporg-site-breadcrumbs {
 	min-height: 23px;
+
+	+ .wp-block-navigation {
+		--navigation-layout-wrap: nowrap;
+	}
+}
+
+@media (max-width: 781px) {
+	.wp-block-wporg-site-breadcrumbs span:not(:first-child,:last-child) {
+		display: none;
+	}
+}
+
+@media (max-width: 599px) {
+	.wporg-site-breadcrumbs-container {
+		width: calc(100% - 44px);
+	}
+
+	.wp-block-wporg-site-breadcrumbs span:not(:first-child) {
+		display: none;
+	}
 }
 
 @media (max-width: 781px) {


### PR DESCRIPTION
Fixes #8 — This updates the site breadcrumbs to show the content hierarchy for categories & articles. I've also tried to add in some responsive handling of the breadcrumbs to prevent too much wrapping, but as you can see when the title is long, it wraps.

- `>781px` shows all breadcrumbs
- `781px-600px` shows the first & last (current page)
- `<600px` shows just the first

In some cases, the articles have more than one category. This uses the first category in the list as the "breadcrumb" category, so if that *isn't* a nested category, only the one category breadcrumb shows up. I'm assuming there will be a category cleanup to match the hierarchy [in this spreadsheet](https://docs.google.com/spreadsheets/d/11RxfocYIC8NjdS5em0yTk4eGGwZPhZbnR7E-CzUGT84/edit#gid=477092427).

### Screenshots

| Size | Home | Topic Landing | Category | Article |
|------|------|---------------|----------|---------|
| 375 | ![1-home-375](https://user-images.githubusercontent.com/541093/207172497-dbc38fcf-1e72-4e8d-a8dd-57895bd1679c.png) | ![2-topic-landing-375](https://user-images.githubusercontent.com/541093/207172504-0e10a742-03c2-4dc8-97ed-8e032109286b.png) | ![3-category-375](https://user-images.githubusercontent.com/541093/207172511-28b83a97-ee37-491a-b54c-e9916e377129.png) | ![4-article-375](https://user-images.githubusercontent.com/541093/207172519-935ba7a3-3c4c-4016-86b2-4687e977f4ac.png) |
| 480 | ![1-home-480](https://user-images.githubusercontent.com/541093/207172498-9a092d7d-7658-4561-ad08-018acd802b19.png) | ![2-topic-landing-480](https://user-images.githubusercontent.com/541093/207172505-9a04d4dc-50c6-4144-a906-dc9705b43d0d.png) | ![3-category-480](https://user-images.githubusercontent.com/541093/207172512-c968d55c-14d8-44f5-896c-7769603fc8cf.png) | ![4-article-480](https://user-images.githubusercontent.com/541093/207172520-0b7ad51c-1d5e-424b-883a-b704c5e0775e.png) |
| 780 | ![1-home-780](https://user-images.githubusercontent.com/541093/207172500-8a0f0ae2-8224-4c13-b22b-a129c25faf76.png) | ![2-topic-landing-780](https://user-images.githubusercontent.com/541093/207172507-aa04a674-f9bf-4852-8733-16a6d16dd0e9.png) | ![3-category-780](https://user-images.githubusercontent.com/541093/207172513-f48bae67-1aed-4b6a-84c4-eb602f01a066.png) | ![4-article-780](https://user-images.githubusercontent.com/541093/207172521-cec3cfed-35a7-401d-bad6-ce0b910eeee9.png) |
| 960 | ![1-home-960](https://user-images.githubusercontent.com/541093/207173234-8ee0830d-e8e9-4984-a74e-2bae43280a42.png) | ![2-topic-landing-960](https://user-images.githubusercontent.com/541093/207172508-373e29d1-b8d1-49d5-a159-5aa2d1293d23.png) | ![3-category-960](https://user-images.githubusercontent.com/541093/207172515-78ac6280-75b5-4aa8-9c6a-d7fc9d7b628f.png) | ![4-article-960](https://user-images.githubusercontent.com/541093/207172522-0accf804-d2ae-4d89-bd43-593bf450e852.png) |
| 1280 | ![1-home-1280](https://user-images.githubusercontent.com/541093/207172501-51908047-e381-4921-b58f-e206e5a8faae.png) | ![2-topic-landing-1280](https://user-images.githubusercontent.com/541093/207172509-9cd80d78-4bf3-4ba3-95aa-ed37dfe5e97a.png) | ![3-category-1280](https://user-images.githubusercontent.com/541093/207172516-4a8db2c2-5c36-440c-95bc-53bedb58d42a.png) | ![4-article-1280](https://user-images.githubusercontent.com/541093/207172523-eaff6a32-8cd5-47df-9ce0-5e9a2befe35a.png) |
| 1440 | ![1-home-1440](https://user-images.githubusercontent.com/541093/207172503-ec1e0fde-bfbf-4f4c-bf92-c78693e35346.png) | ![2-topic-landing-1440](https://user-images.githubusercontent.com/541093/207172510-29acf822-fd4e-4ef3-9b06-bbb69da9414a.png) | ![3-category-1440](https://user-images.githubusercontent.com/541093/207172518-21b6323d-5117-416c-b5b8-5f5114704524.png) | ![4-article-1440](https://user-images.githubusercontent.com/541093/207172525-a7809920-88fa-4518-8cc1-3191c58ee380.png) |

### How to test the changes in this Pull Request:

1. You'll need to set up some nested categories
    1. Create a new category called Technical Guides
    2. Make that the parent category of Installation, Maintenance, and Security
    3. Create a page called Technical Guides (see #4 for some example content)
2. Click through various pages and make sure the breadcrumbs work as expected (home, categories, articles, wp versions, etc)
3. Try at different browser sizes, it shouldn't be too broken (though nitpicks can be addressed in a design review)

cc @estelaris, @javierarce