### PR TITLE
Fix accessibility around search and feedback forms

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -182,7 +182,7 @@ function comment_form_defaults( $fields ) {
 
 	$str_log_in = sprintf(
 		/* translators: 1: log in link, 2: support forums link. */
-		__( '<a href="%1$s">Log in</a> to submit feedback. If you need suppport with something that wasn&#39;t covered by this article, please post your question in the <a href="%2$s">support forums</a>.', 'wporg-docs' ),
+		__( '<a href="%1$s">Log in to submit feedback</a> If you need support with something that wasn&#39;t covered by this article, please post your question in the <a href="%2$s">support forums</a>.', 'wporg-docs' ),
 		esc_url( wp_login_url( apply_filters( 'the_permalink', get_permalink( $post_id ), $post_id ) ) ),
 		esc_url( $forums_url )
 	);

--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -182,7 +182,7 @@ function comment_form_defaults( $fields ) {
 
 	$str_log_in = sprintf(
 		/* translators: 1: log in link, 2: support forums link. */
-		__( '<a href="%1$s">Log in to submit feedback</a> If you need support with something that wasn&#39;t covered by this article, please post your question in the <a href="%2$s">support forums</a>.', 'wporg-docs' ),
+		__( '<a href="%1$s">Log in to submit feedback</a>. If you need support with something that wasn&#39;t covered by this article, please post your question in the <a href="%2$s">support forums</a>.', 'wporg-docs' ),
 		esc_url( wp_login_url( apply_filters( 'the_permalink', get_permalink( $post_id ), $post_id ) ) ),
 		esc_url( $forums_url )
 	);

--- a/source/wp-content/themes/wporg-documentation-2022/parts/search.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/search.html
@@ -1,1 +1,1 @@
-<!-- wp:search {"label":"Search","showLabel":false,"width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","placeholder":"Search documentation for…"} /-->
+<!-- wp:search {"label":"Search documentation","showLabel":false,"width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","placeholder":"Search documentation for…"} /-->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Fix a few accessibility bugs around the search and feedback forms.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->

<!-- List out anyone who helped with this task. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Before | After |
|--------|-------|
| image  | image |

### How to test the changes in this Pull Request:

1. Enable a screen reader.
2. Notice how the search form now has a more fitting label to match the placeholder text more closely.
3. Instead of "Log in", it now says "Log in to submit feedback" for better context.
4. Fix typo on "suppport" to "support".

<!-- If you can, add the appropriate [Component] label(s). -->
