### PR TITLE
Restructure single template to follow a better DOM structure for A11Y

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -10,17 +10,17 @@
 		<article class="wp-block-group">
 			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}}} /-->
 
-			<!-- wp:group {"tagName":"aside","className":"sidebar-container"} -->
-			<aside class="wp-block-group sidebar-container">
-				<!-- wp:template-part {"slug":"search"} /-->
+		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|50"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+		<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+			<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+			<p style="font-style:normal;font-weight:700">First published: <!-- wp:post-date {"fontSize":"normal"} /--></p>
+			<!-- /wp:paragraph -->
 
-				<!-- wp:wporg/table-of-contents {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"blueberry-1"} /-->
-
-				<!-- wp:paragraph {"fontSize":"small","className":"is-link-to-top"} -->
-				<p class="has-small-font-size is-link-to-top"><a href="#wp--skip-link--target">↑ Back to top</a></p>
-				<!-- /wp:paragraph -->
-			</aside>
-			<!-- /wp:group -->
+			<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+			<p style="font-style:normal;font-weight:700">Last updated: <!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /--></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
 
 			<!-- wp:post-content {"layout":{"inherit":true}} /-->
 		</article>
@@ -31,30 +31,6 @@
 			<!-- wp:post-comments-form /-->
 		</div>
 		<!-- /wp:group -->
-
-		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|50"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-		<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
-			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group">
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-				<p style="font-style:normal;font-weight:700">First published</p>
-				<!-- /wp:paragraph -->
-		
-				<!-- wp:post-date {"fontSize":"normal"} /-->
-			</div>
-			<!-- /wp:group -->
-		
-			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group">
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-				<p style="font-style:normal;font-weight:700">Last updated</p>
-				<!-- /wp:paragraph -->
-		
-				<!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /-->
-			</div>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
 
@@ -62,6 +38,18 @@
 	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 </main>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"aside","className":"sidebar-container"} -->
+<aside class="wp-block-group sidebar-container">
+	<!-- wp:wporg/table-of-contents {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"blueberry-1"} /-->
+
+	<!-- wp:template-part {"slug":"search"} /-->
+
+	<!-- wp:paragraph {"fontSize":"small","className":"is-link-to-top"} -->
+	<p class="has-small-font-size is-link-to-top"><a href="#wp--skip-link--target">↑ Back to top</a></p>
+	<!-- /wp:paragraph -->
+</aside>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -10,17 +10,19 @@
 		<article class="wp-block-group">
 			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}}} /-->
 
-		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|50"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-		<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
-			<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-			<p style="font-style:normal;font-weight:700">First published: <!-- wp:post-date {"fontSize":"normal"} /--></p>
-			<!-- /wp:paragraph -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|50"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+				<p style="font-style:normal;font-weight:700">First published: <!-- wp:post-date {"fontSize":"normal"} /--></p>
+				<!-- /wp:paragraph -->
 
-			<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-			<p style="font-style:normal;font-weight:700">Last updated: <!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /--></p>
-			<!-- /wp:paragraph -->
-		</div>
-		<!-- /wp:group -->
+				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+				<p style="font-style:normal;font-weight:700">Last updated: <!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /--></p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+
+			<!-- wp:wporg/table-of-contents {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"blueberry-1"} /-->
 
 			<!-- wp:post-content {"layout":{"inherit":true}} /-->
 		</article>
@@ -42,8 +44,6 @@
 
 <!-- wp:group {"tagName":"aside","className":"sidebar-container"} -->
 <aside class="wp-block-group sidebar-container">
-	<!-- wp:wporg/table-of-contents {"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-1"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"blueberry-4","textColor":"blueberry-1"} /-->
-
 	<!-- wp:template-part {"slug":"search"} /-->
 
 	<!-- wp:paragraph {"fontSize":"small","className":"is-link-to-top"} -->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

The largest change places the sidebar after the closing `</main>` for better ARIA landmark support/DOM structure for accessibility. Many visual regressions will be caused by this PR, hoping Meta Team can help out with CSS adjustments.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->

<!-- List out anyone who helped with this task. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Before | After |
|--------|-------|
| image  | image |

### How to test the changes in this Pull Request:

1. Open a single doc article.
2. Notice the sidebar is moved.
3. Notice meta information appears just below the main heading 1/article title.

<!-- If you can, add the appropriate [Component] label(s). -->
