### PR TITLE
Add back the Get Involved menu item.

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -355,6 +355,10 @@ function add_site_navigation_menus( $menus ) {
 				'label' => __( 'Customization', 'wporg-docs' ),
 				'url' => '/customization/',
 			),
+			array(
+				'label' => __( 'Get Involved', 'wporg-docs' ),
+				'url' => 'https://make.wordpress.org/docs/',
+			),
 		),
 	);
 }


### PR DESCRIPTION
The PR adds back the [Get Involved](https://make.wordpress.org/docs/) menu item to the new secondary navigation menu based on [community feedback](https://wordpress.slack.com/archives/C04U953K77A/p1694555656016189). 

This PR should be seen as an interim step until the new design of the Documentation section is finalized. To leave feedback on the broader design, see the corresponding [Figma file](https://www.figma.com/file/iM8I9yAYbwjbc9q9b2WWui/Documentation%2FHelpHub?node-id=3833%3A2517&mode=dev). 

### Screenshots

| Before | After |
|--------|-------|
| <img width="1412" alt="image" src="https://github.com/WordPress/wporg-documentation-2022/assets/4832319/048d6c9e-7548-4729-b73b-90ba9604b6b7">  | <img width="1412" alt="image" src="https://github.com/WordPress/wporg-documentation-2022/assets/4832319/26d82f7c-4cd4-4785-b210-87281def6074"> |
