### PR TITLE
Move breadcrumbs outside of sticky container in header.

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/parts/header.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:wporg/global-header /-->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"}},"backgroundColor":"charcoal-2","className":"is-sticky","layout":{"type":"constrained"}} -->
+<!-- wp:group {"align":"full","backgroundColor":"charcoal-2","className":"is-sticky","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-sticky has-charcoal-2-background-color has-background">
 	
 	<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"18px","bottom":"18px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|white-opacity-15","width":"1px"}}}} -->
@@ -10,14 +10,14 @@
 		<!-- wp:navigation {"menuSlug":"documentation","hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 
 	<!-- /wp:wporg/local-navigation-bar -->
-	
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
 		
-		<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
-	
-	</div>
-	<!-- /wp:group -->
+	<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
 
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
This PR moves the breadcrumbs section outside of the sticky containers. Which is more in line with the [original design](https://www.figma.com/proto/iM8I9yAYbwjbc9q9b2WWui/Documentation%2FHelpHub?node-id=3833-28422&scaling=min-zoom&page-id=3833%3A2517&starting-point-node-id=3833%3A28422) and reduces the amount of sticky content on the screen.

### Screenshots

| Before | After |
|--------|-------|
| ![sticky-header-previous](https://github.com/WordPress/wporg-documentation-2022/assets/4832319/260efc66-c7c4-41b6-ae75-0f72abcc517f)  | ![sticky-header-2](https://github.com/WordPress/wporg-documentation-2022/assets/4832319/134ef6af-2b40-4b0b-90fd-bc8985c8d6e7) |

