### PR TITLE
Move breadcrumb outside sticky header

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/parts/header.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header.html
@@ -1,23 +1,11 @@
 <!-- wp:wporg/global-header /-->
 
-<!-- wp:group {"align":"full","backgroundColor":"charcoal-2","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-charcoal-2-background-color has-background">
-	
-	<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"18px","bottom":"18px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|white-opacity-15","width":"1px"}}}} -->
-	
-		<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
-		
-		<!-- wp:navigation {"hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"documentation"} /-->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"18px","bottom":"18px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|white-opacity-15","width":"1px"}}}} -->
 
-	<!-- /wp:wporg/local-navigation-bar -->
+	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-</div>
-<!-- /wp:group -->
+	<!-- wp:navigation {"hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"documentation"} /-->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"default"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0;padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- /wp:wporg/local-navigation-bar -->
 
-	<!-- wp:wporg/site-breadcrumbs {"align":"full","fontSize":"small"} /-->
-
-</div>
-<!-- /wp:group -->
+<!-- wp:wporg/site-breadcrumbs {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"fontSize":"small"} /-->

--- a/source/wp-content/themes/wporg-documentation-2022/parts/header.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header.html
@@ -7,17 +7,17 @@
 	
 		<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 		
-		<!-- wp:navigation {"menuSlug":"documentation","hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+		<!-- wp:navigation {"hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"documentation"} /-->
 
 	<!-- /wp:wporg/local-navigation-bar -->
 
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
-		
-	<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0;padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:wporg/site-breadcrumbs {"align":"full","fontSize":"small"} /-->
 
 </div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-documentation-2022/parts/header.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:wporg/global-header /-->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"}},"backgroundColor":"charcoal-2","className":"is-sticky","layout":{"type":"constrained"}} -->
+<!-- wp:group {"align":"full","backgroundColor":"charcoal-2","className":"is-sticky","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-sticky has-charcoal-2-background-color has-background">
 	
 	<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"18px","bottom":"18px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|white-opacity-15","width":"1px"}}}} -->
@@ -10,14 +10,14 @@
 		<!-- wp:navigation {"menuSlug":"documentation","hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 
 	<!-- /wp:wporg/local-navigation-bar -->
-	
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
 		
-		<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
-	
-	</div>
-	<!-- /wp:group -->
+	<!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /-->
 
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
See #69 

Props @ndiego 

This PR updates the markup from the above PR which was invalid when parsed by the editor. The layout remains the same.

### Screenshots

| Desktop | Desktop scrolled | Mobile | 
|--------|-------|-|
| ![localhost_8888_article_optimization_(Desktop) (1)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/05dd1745-44e5-40bb-9922-fa72a6db5217) | ![localhost_8888_article_optimization_(Desktop) (scrolled)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/28ca818c-4441-4154-8aa7-0778c792a9d5) | ![localhost_8888_article_optimization_(Samsung Galaxy S20 Ultra) (1)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/e2f875e6-557d-4729-8839-7830b4c10ebf) |

### How to test the changes in this Pull Request:

1. Load a [category page](http://localhost:8888/category/installation/) and [article page](http://localhost:8888/article/optimization/). 
2. Check the breadcrumbs are responsive and not sticky