### PR TITLE
Headers: Use native sticky local navigation bar & site breadcrumbs

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/parts/header-home.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header-home.html
@@ -1,17 +1,11 @@
-<!-- wp:wporg/global-header /-->
+<!-- wp:wporg/global-header {"style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"charcoal-2","textColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color">
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 
-	<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"18px","bottom":"18px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|white-opacity-15","width":"1px"}}}} -->
+	<!-- wp:html -->
+	<div style="height:calc(var(--wp--custom--body--small--typography--line-height) * var(--wp--preset--font-size--small));" aria-hidden="true"></div>
+	<!-- /wp:html -->
 
-		<!-- wp:html -->
-		<div style="height:calc(var(--wp--custom--body--small--typography--line-height) * var(--wp--preset--font-size--small));" aria-hidden="true"></div>
-		<!-- /wp:html -->
+	<!-- wp:navigation {"menuSlug":"documentation","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 
-		<!-- wp:navigation {"menuSlug":"documentation","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
-
-	<!-- /wp:wporg/local-navigation-bar -->
-
-</div>
-<!-- /wp:group -->
+<!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-documentation-2022/parts/header-topic-landing.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header-topic-landing.html
@@ -1,15 +1,9 @@
-<!-- wp:wporg/global-header /-->
+<!-- wp:wporg/global-header {"style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"charcoal-2","textColor":"white","className":"is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-sticky has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color">
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 
-	<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60","top":"18px","bottom":"18px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|white-opacity-15","width":"1px"}}}} -->
+	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-		<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
+	<!-- wp:navigation {"menuSlug":"documentation","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 
-		<!-- wp:navigation {"menuSlug":"documentation","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
-
-	<!-- /wp:wporg/local-navigation-bar -->
-
-</div>
-<!-- /wp:group -->
+<!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-documentation-2022/parts/header.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header.html
@@ -1,6 +1,6 @@
-<!-- wp:wporg/global-header /-->
+<!-- wp:wporg/global-header {"style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
 
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"18px","bottom":"18px"}},"position":{"type":"sticky"},"border":{"top":{"color":"var:preset|color|white-opacity-15","width":"1px"}}}} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-2","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 
 	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
@@ -8,4 +8,6 @@
 
 <!-- /wp:wporg/local-navigation-bar -->
 
-<!-- wp:wporg/site-breadcrumbs {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"fontSize":"small"} /-->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"position":{"type":"sticky"}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /--></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-documentation-2022/parts/header.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header.html
@@ -8,6 +8,6 @@
 
 <!-- /wp:wporg/local-navigation-bar -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"position":{"type":"sticky"}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /--></div>
 <!-- /wp:group -->


### PR DESCRIPTION
This will be necessary if https://github.com/WordPress/wporg-mu-plugins/pull/466 merges, because the sticky behavior will change. This should make it easier to implement sticky bars on child themes, but does require updating the current sites that are using the older `is-sticky` class.

Other changes I made:

- Removing the padding on `local-navigation-bar`, this is set correctly by default now
- Move the border from `local-navigation-bar` to the global header, this looks better when the page scrolls
- Since the `local-navigation-bar` was moved out of the group, I moved the `style` attribute to `local-navigation-bar` directly

### Screenshots

This fixes an issue with the homepage scroll, and makes the breadcrumbs sticky.

| Screen | Before | After |
|---|--------|-------|
| Home | ![before-home-top](https://github.com/WordPress/wporg-documentation-2022/assets/541093/0be86bf6-f70e-4225-82ef-6d83a1466d4e) | ![after-home-top](https://github.com/WordPress/wporg-documentation-2022/assets/541093/0f800f94-3828-48da-af33-53289b3ce4c7) |
| Home scrolled | ![before-home-scroll](https://github.com/WordPress/wporg-documentation-2022/assets/541093/44ee887e-f6c4-4f52-838d-99f2fffd2be3) | ![after-home-scroll](https://github.com/WordPress/wporg-documentation-2022/assets/541093/1f00b893-00cc-43d0-9726-e40770d7b9ec) |
| Article | ![before-article-top](https://github.com/WordPress/wporg-documentation-2022/assets/541093/a655f89c-b337-44db-83f3-b03f5512dcd1) | ![after-article-top](https://github.com/WordPress/wporg-documentation-2022/assets/541093/bd5e5228-af83-4e82-92c0-ee082a8977e9) |
| Article scrolled | ![before-article-scroll](https://github.com/WordPress/wporg-documentation-2022/assets/541093/e51d32f1-6111-4f3d-8920-89a33ce26350) | ![after-article-scroll](https://github.com/WordPress/wporg-documentation-2022/assets/541093/27d0de05-da8b-4a23-b2cc-56df067abd30) |

### How to test the changes in this Pull Request:

1. Apply the wporg-mu-plugins PR
2. View any pages — the global header is no longer sticky, local nav is, and breadcrumbs (when they appear) are.
