### PR TITLE
Use chevron icon for local nav mobile menu

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/parts/header-home.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header-home.html
@@ -9,7 +9,7 @@
 		<div style="height:calc(var(--wp--custom--body--small--typography--line-height) * var(--wp--preset--font-size--small));" aria-hidden="true"></div>
 		<!-- /wp:html -->
 
-		<!-- wp:navigation {"menuSlug":"documentation","hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+		<!-- wp:navigation {"menuSlug":"documentation","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 
 	<!-- /wp:wporg/local-navigation-bar -->
 

--- a/source/wp-content/themes/wporg-documentation-2022/parts/header-topic-landing.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header-topic-landing.html
@@ -7,7 +7,7 @@
 
 		<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-		<!-- wp:navigation {"menuSlug":"documentation","hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+		<!-- wp:navigation {"menuSlug":"documentation","icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 
 	<!-- /wp:wporg/local-navigation-bar -->
 

--- a/source/wp-content/themes/wporg-documentation-2022/parts/header.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/header.html
@@ -4,7 +4,7 @@
 
 	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-	<!-- wp:navigation {"hasIcon":false,"overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"documentation"} /-->
+	<!-- wp:navigation {"icon":"menu","overlayBackgroundColor":"charcoal-2","overlayTextColor":"white","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","menuSlug":"documentation"} /-->
 
 <!-- /wp:wporg/local-navigation-bar -->
 


### PR DESCRIPTION
Closes #72
Depends on https://github.com/WordPress/wporg-mu-plugins/pull/480.

### Screenshots

| Page:State | Before | After |
|--------|-------|-|
| Home:Closed | ![localhost_8888_(Samsung Galaxy S20 Ultra) (24)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/3d1f2b06-40c2-47a9-9df0-15325f8637ba) | ![localhost_8888_(Samsung Galaxy S20 Ultra) (26)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/53c48a77-2c4d-4c29-9653-d69cb2a79c95) |
| Home:Open | ![localhost_8888_(Samsung Galaxy S20 Ultra) (25)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/35d666d2-41fc-4488-b4f8-84204487696e) | ![localhost_8888_(Samsung Galaxy S20 Ultra) (27)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/61491a98-9b44-4364-bab8-c6fd75e7c896) |
| Landing:Closed | ![localhost_8888_overview_(Samsung Galaxy S20 Ultra) (1)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/6ac32a3b-8ab9-4990-bc6d-fd462d521a41) | ![localhost_8888_overview_(Samsung Galaxy S20 Ultra) (3)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/73d8fc38-f100-46da-91f6-ab8cd6782652) |
| Landing:Open | ![localhost_8888_overview_(Samsung Galaxy S20 Ultra) (2)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/e9fad7d8-0626-43f2-9660-9dbda5061177) | ![localhost_8888_overview_(Samsung Galaxy S20 Ultra) (4)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/9ced84c9-05fc-4263-a53e-db6a68ed37c1) |
| Article:Closed | ![localhost_8888_article_block-directory_(Samsung Galaxy S20 Ultra) (3)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/84e06bbe-0f01-42f7-8bcb-722435126c81) | ![localhost_8888_article_block-directory_(Samsung Galaxy S20 Ultra) (1)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/f18afd0c-dedb-441c-8423-83ae605282fd) |
| Article:Open | ![localhost_8888_article_block-directory_(Samsung Galaxy S20 Ultra) (4)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/e99e43d6-debb-4bb1-af92-837390570c7b) | ![localhost_8888_article_block-directory_(Samsung Galaxy S20 Ultra) (2)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/95eb9840-631b-4d82-b0e4-3a2db2e08e5a) | 

### How to test the changes in this Pull Request:

1. Unsure your mu-plugins is on https://github.com/WordPress/wporg-mu-plugins/pull/480
2. Open [home](http://localhost:8888/), a [landing page](http://localhost:8888/technical-guides/) and an [article page](http://localhost:8888/article/block-directory/)
3. Simulate mobile screen size
4. Check that the icon in the mobile menu button is a chevron
5. Open the menu
6. Check the the chevron icon has been flipper vertically
7. Close the menu