### PR TITLE
Remove extra space above ToC when scrolled and fix ToC/footer behaviour

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -3,11 +3,6 @@
  * templates or theme.json settings.
  */
 
-body[class] {
-	// Height of the local header (breadcrumbs & subnav).
-	--wp-local-header-offset: 57px;
-}
-
 // Underline links inside query blocks to match post content behavior.
 .wp-block-post a {
 	text-decoration-line: underline;
@@ -59,4 +54,8 @@ p.has-background {
 			padding-left: 0 !important;
 		}
 	}
+}
+
+.single-helphub_article main {
+	position: relative;
 }

--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -1,10 +1,10 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-<main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"layout":{"type":"constrained"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
+<div class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide"} -->
-	<div class="wp-block-group alignwide">
+	<!-- wp:group {"tagName":"main","layout":{"type":"constrained","justifyContent":"left"},"align":"wide","spacing":{"padding":{"bottom":"var:preset|spacing|edge-space"}}} -->
+	<main class="wp-block-group alignwide" style="padding-bottom: var(--wp--preset--spacing--edge-space)">
 
 		<!-- wp:group {"tagName":"article"} -->
 		<article class="wp-block-group">
@@ -45,13 +45,9 @@
 			<!-- /wp:group -->
 		</div>
 		<!-- /wp:group -->
-	</div>
+	</main>
 	<!-- /wp:group -->
-
-	<!-- wp:spacer {"height":"40px"} -->
-	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
-</main>
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-documentation-2022/theme.json
+++ b/source/wp-content/themes/wporg-documentation-2022/theme.json
@@ -1,7 +1,24 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
-	"settings": {},
+	"settings": {
+		"custom": {
+			"wporg-sidebar-container": {
+				"spacing": {
+					"margin": {
+						"top": "-60px"
+					}
+				},
+				"width": "340px",
+				"position": {
+					"right": {
+						"default": "0",
+						"fixed":  "max(var(--wp--preset--spacing--edge-space), calc((100% - var(--wp--style--global--wide-size)) / 2))"
+					}
+				}
+			}
+		}
+	},
 	"styles": {
 		"blocks": {
 			"core/preformatted": {


### PR DESCRIPTION
See https://github.com/WordPress/wporg-mu-plugins/issues/524
Depends on https://github.com/WordPress/wporg-mu-plugins/pull/525

The ToC now scrolls up with the page until it reaches 60px (matches local nav height) below the fixed local nav, where it becomes fixed. When scrolling to the bottom it will become unfixed when it reaches 80px above the footer (matches edge space).

### Before


### After