### PR TITLE
Add redirect for urls that was missing

### DIFF
--- a/source/wp-content/mu-plugins/site-documentation.php
+++ b/source/wp-content/mu-plugins/site-documentation.php
@@ -76,6 +76,7 @@ function redirect_old_content() {
 		'/documentation/article/hardening-wordpress/'                               => 'https://developer.wordpress.org/advanced-administration/security/hardening/',
 		'/documentation/article/how-to-install-wordpress/'                          => 'https://developer.wordpress.org/advanced-administration/before-install/howto-install/',
 		'/documentation/article/htaccess/'                                          => 'https://developer.wordpress.org/advanced-administration/server/web-server/httpd/',
+		'/documentation/article/https-for-wordpress/'                               => 'https://developer.wordpress.org/advanced-administration/security/https/',
 		'/documentation/article/importing-content/'                                 => 'https://developer.wordpress.org/advanced-administration/wordpress/import/',
 		'/documentation/article/installing-multiple-blogs/'                         => 'https://developer.wordpress.org/advanced-administration/before-install/multiple-instances/',
 		'/documentation/article/installing-wordpress-at-popular-hosting-companies/' => 'https://developer.wordpress.org/advanced-administration/before-install/popular-providers/',

--- a/source/wp-content/mu-plugins/site-documentation.php
+++ b/source/wp-content/mu-plugins/site-documentation.php
@@ -67,6 +67,7 @@ function redirect_old_content() {
 		'/documentation/article/debugging-a-wordpress-network/'                     => 'https://developer.wordpress.org/advanced-administration/debug/debug-network/',
 		'/documentation/article/debugging-in-wordpress/'                            => 'https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/',
 		'/documentation/article/editing-files/'                                     => 'https://developer.wordpress.org/advanced-administration/wordpress/edit-files/',
+		'/documentation/article/editing-wp-config-php/'                             => 'https://developer.wordpress.org/advanced-administration/wordpress/wp-config/',
 		'/documentation/article/embeds/'                                            => 'https://developer.wordpress.org/advanced-administration/wordpress/oembed/',
 		'/documentation/article/emptying-a-database-table/'                         => 'https://developer.wordpress.org/advanced-administration/server/empty-database/',
 		'/documentation/article/faq-troubleshooting-2/'                             => 'https://developer.wordpress.org/advanced-administration/resources/faq/',
@@ -108,6 +109,7 @@ function redirect_old_content() {
 		'/documentation/article/using-your-browser-to-diagnose-javascript-errors/'  => 'https://developer.wordpress.org/advanced-administration/debug/debug-javascript/',
 		'/documentation/article/why-should-i-use-https/'                            => 'https://developer.wordpress.org/advanced-administration/security/https/',
 		'/documentation/article/wordpress-backups/'                                 => 'https://developer.wordpress.org/advanced-administration/security/backup/',
+		'/documentation/article/wordpress-feeds/'                                   => 'https://developer.wordpress.org/advanced-administration/wordpress/feeds/',
 		'/documentation/article/wordpress-multisite-domain-mapping/'                => 'https://developer.wordpress.org/advanced-administration/multisite/domain-mapping/',
 	];
 

--- a/source/wp-content/mu-plugins/site-documentation.php
+++ b/source/wp-content/mu-plugins/site-documentation.php
@@ -68,7 +68,6 @@ function redirect_old_content() {
 		'/documentation/article/debugging-in-wordpress/'                            => 'https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/',
 		'/documentation/article/editing-files/'                                     => 'https://developer.wordpress.org/advanced-administration/wordpress/edit-files/',
 		'/documentation/article/editing-wp-config-php/'                             => 'https://developer.wordpress.org/advanced-administration/wordpress/wp-config/',
-		'/documentation/article/embeds/'                                            => 'https://developer.wordpress.org/advanced-administration/wordpress/oembed/',
 		'/documentation/article/emptying-a-database-table/'                         => 'https://developer.wordpress.org/advanced-administration/server/empty-database/',
 		'/documentation/article/faq-troubleshooting-2/'                             => 'https://developer.wordpress.org/advanced-administration/resources/faq/',
 		'/documentation/article/finding-server-info/'                               => 'https://developer.wordpress.org/advanced-administration/server/server-info/',


### PR DESCRIPTION
It was pointed that "Editing wp-config.php" [was moved to a new location](https://wordpress.slack.com/archives/C02RP4WU5/p1709831716830609) but the redirect seems to be missing.
After looking at https://github.com/WordPress/Documentation-Issue-Tracker/issues/1102, I happened to find another article with redirect missing so added it too.

### How to test the changes in this Pull Request:
The urls below should be redirected.
1. https://wordpress.org/documentation/article/editing-wp-config-php/ -> https://developer.wordpress.org/advanced-administration/wordpress/wp-config/
2. https://wordpress.org/documentation/article/wordpress-feeds/ -> https://developer.wordpress.org/advanced-administration/wordpress/feeds/