### PR TITLE
Fix the position of the Table of Contents

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/parts/search.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/search.html
@@ -1,1 +1,1 @@
-<!-- wp:search {"label":"Search documentation","showLabel":false,"width":232,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","placeholder":"Search documentation for…"} /-->
+<!-- wp:search {"label":"Search documentation","showLabel":false,"width":235,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","placeholder":"Search documentation"} /-->

--- a/source/wp-content/themes/wporg-documentation-2022/parts/search.html
+++ b/source/wp-content/themes/wporg-documentation-2022/parts/search.html
@@ -1,1 +1,1 @@
-<!-- wp:search {"label":"Search documentation","showLabel":false,"width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","placeholder":"Search documentation for…"} /-->
+<!-- wp:search {"label":"Search documentation","showLabel":false,"width":232,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control","placeholder":"Search documentation for…"} /-->

--- a/source/wp-content/themes/wporg-documentation-2022/patterns/article-sidebar.php
+++ b/source/wp-content/themes/wporg-documentation-2022/patterns/article-sidebar.php
@@ -7,7 +7,5 @@
 
 ?>
 <!-- wp:wporg/sidebar-container {"style":{"spacing":{"margin":{"bottom":"40px"}}}} -->
-	<!-- wp:template-part {"slug":"search","theme":"wporg-documentation-2022"} /-->
-
 	<!-- wp:wporg/table-of-contents /-->
 <!-- /wp:wporg/sidebar-container -->

--- a/source/wp-content/themes/wporg-documentation-2022/templates/archive.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/archive.html
@@ -1,5 +1,13 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:template-part {"slug":"search","theme":"wporg-documentation-2022"} /-->
+
+</div>
+<!-- /wp:group -->
+
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
 <main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 	<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}}} -->
@@ -9,12 +17,6 @@
 			<!-- wp:query-title {"type":"archive","level":1} /-->
 	
 			<!-- wp:term-description {"style":{"spacing":{"margin":{"top":"8px"}}},"textColor":"charcoal-4"} /-->
-		</div>
-		<!-- /wp:column -->
-		
-		<!-- wp:column {"width":"33.33%"} -->
-		<div class="wp-block-column" style="flex-basis:33.33%">
-			<!-- wp:template-part {"slug":"search"} /-->
 		</div>
 		<!-- /wp:column -->
 	</div>

--- a/source/wp-content/themes/wporg-documentation-2022/templates/archive.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/archive.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:template-part {"slug":"search","theme":"wporg-documentation-2022"} /-->
 

--- a/source/wp-content/themes/wporg-documentation-2022/templates/page-topic-landing.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/page-topic-landing.html
@@ -1,24 +1,25 @@
 <!-- wp:template-part {"slug":"header-topic-landing","className":"has-display-contents"} /-->
 
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:template-part {"slug":"search","theme":"wporg-documentation-2022"} /-->
+
+</div>
+<!-- /wp:group -->
+
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-<main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}}} -->
-	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--edge-space);margin-bottom:var(--wp--preset--spacing--40)">
-		<!-- wp:column {"width":"66.66%"} -->
-		<div class="wp-block-column" style="flex-basis:66.66%">
-			<!-- wp:post-title {"level":1} /-->
-	
-			<!-- wp:term-description {"style":{"spacing":{"margin":{"top":"8px"}}},"textColor":"charcoal-4"} /-->
-		</div>
-		<!-- /wp:column -->
+<main class="wp-block-group alignwide" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}}} -->
+	<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--edge-space);margin-bottom:var(--wp--preset--spacing--40)">
 		
-		<!-- wp:column {"width":"33.33%"} -->
-		<div class="wp-block-column" style="flex-basis:33.33%">
-			<!-- wp:template-part {"slug":"search"} /-->
-		</div>
-		<!-- /wp:column -->
+		<!-- wp:post-title {"level":1} /-->
+
+		<!-- wp:term-description {"style":{"spacing":{"margin":{"top":"8px"}}},"textColor":"charcoal-4"} /-->
+		
 	</div>
-	<!-- /wp:columns -->
+	<!-- /wp:group -->
 
 	<!-- wp:group {"tagName":"article","align":"wide","layout":{"type":"default"}} -->
 	<article class="wp-block-group alignwide">

--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -1,57 +1,75 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} -->
-<main class="wp-block-group alignfull" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"className":"alignfull","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"},"align":"wide"} -->
-	<div class="wp-block-group alignwide">
+	<!-- wp:template-part {"slug":"search","theme":"wporg-documentation-2022"} /-->
 
-		<!-- wp:group {"tagName":"article"} -->
-		<article class="wp-block-group">
-			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}}} /-->
+</div>
+<!-- /wp:group -->
 
-			<!-- wp:pattern {"slug":"wporg-documentation-2022/article-sidebar"} /-->
-
-			<!-- wp:post-content {"layout":{"inherit":true}} /-->
-		</article>
-		<!-- /wp:group -->
-
-		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}} -->
-		<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
-			<!-- wp:post-comments-form /-->
-		</div>
-		<!-- /wp:group -->
-
-		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|50"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-		<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
-			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group">
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-				<p style="font-style:normal;font-weight:700">First published</p>
-				<!-- /wp:paragraph -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+	
+	<!-- wp:group {"align":"left","className":"has-three-columns","layout":{"type":"flex","flexWrap":"wrap","orientation":"vertical"}} -->
+	<div class="wp-block-group alignleft has-three-columns">
 		
-				<!-- wp:post-date {"fontSize":"normal"} /-->
+		<!-- wp:group {"tagName":"main","className":"alignwide"} -->
+		<main class="wp-block-group alignwide">
+
+			<!-- wp:group {"tagName":"article","style":{"spacing":{"margin":{"top":"0px"}}}} -->
+			<article class="wp-block-group" style="margin-top:0px">
+				<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|40"}}}} /-->
+
+				<!-- wp:pattern {"slug":"wporg-documentation-2022/article-sidebar"} /-->
+
+				<!-- wp:post-content {"layout":{"inherit":true}} /-->
+			</article>
+			<!-- /wp:group -->
+
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}} -->
+			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+				<!-- wp:post-comments-form /-->
 			</div>
 			<!-- /wp:group -->
-		
-			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group">
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-				<p style="font-style:normal;font-weight:700">Last updated</p>
-				<!-- /wp:paragraph -->
-		
-				<!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /-->
+
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|50"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+				
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+					<p style="font-style:normal;font-weight:700">First published</p>
+					<!-- /wp:paragraph -->
+			
+					<!-- wp:post-date {"fontSize":"normal"} /-->
+				</div>
+				<!-- /wp:group -->
+			
+				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+					<p style="font-style:normal;font-weight:700">Last updated</p>
+					<!-- /wp:paragraph -->
+			
+					<!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /-->
+				</div>
+				<!-- /wp:group -->
+
 			</div>
 			<!-- /wp:group -->
-		</div>
+
+			<!-- wp:spacer {"height":"40px"} -->
+			<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+
+		</main>
 		<!-- /wp:group -->
+
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:spacer {"height":"40px"} -->
-	<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
-</main>
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/source/wp-content/themes/wporg-documentation-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-documentation-2022/templates/single.html
@@ -24,39 +24,41 @@
 				<!-- wp:pattern {"slug":"wporg-documentation-2022/article-sidebar"} /-->
 
 				<!-- wp:post-content {"layout":{"inherit":true}} /-->
-			</article>
-			<!-- /wp:group -->
+			
 
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}} -->
-			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
-				<!-- wp:post-comments-form /-->
-			</div>
-			<!-- /wp:group -->
+				<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}} -->
+				<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+					<!-- wp:post-comments-form /-->
+				</div>
+				<!-- /wp:group -->
 
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|50"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+				<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|50"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+				<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-top:var(--wp--preset--spacing--40)">
+					
+					<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+					<div class="wp-block-group">
+						<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+						<p style="font-style:normal;font-weight:700">First published</p>
+						<!-- /wp:paragraph -->
 				
-				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group">
-					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-					<p style="font-style:normal;font-weight:700">First published</p>
-					<!-- /wp:paragraph -->
-			
-					<!-- wp:post-date {"fontSize":"normal"} /-->
-				</div>
-				<!-- /wp:group -->
-			
-				<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group">
-					<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
-					<p style="font-style:normal;font-weight:700">Last updated</p>
-					<!-- /wp:paragraph -->
-			
-					<!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /-->
+						<!-- wp:post-date {"fontSize":"normal"} /-->
+					</div>
+					<!-- /wp:group -->
+				
+					<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+					<div class="wp-block-group">
+						<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+						<p style="font-style:normal;font-weight:700">Last updated</p>
+						<!-- /wp:paragraph -->
+				
+						<!-- wp:post-date {"displayType":"modified","fontSize":"normal"} /-->
+					</div>
+					<!-- /wp:group -->
+
 				</div>
 				<!-- /wp:group -->
 
-			</div>
+			</article>
 			<!-- /wp:group -->
 
 			<!-- wp:spacer {"height":"40px"} -->

--- a/source/wp-content/themes/wporg-documentation-2022/theme.json
+++ b/source/wp-content/themes/wporg-documentation-2022/theme.json
@@ -1,7 +1,16 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
-	"settings": {},
+	"settings": {
+		"custom": {
+			"alignment": {
+				"aligned-max-width": "100%"
+			}
+		},
+		"layout": {
+			"contentSize": "960px"
+		}
+	},
 	"styles": {
 		"blocks": {
 			"core/preformatted": {


### PR DESCRIPTION
This PR updates the single page template to use the 3 column layout from the parent theme. This brings alignment with the single pages on Developer Resources, and fixes the incorrect positioning resulting from https://github.com/WordPress/gutenberg/pull/60347. In implementing this layout I've also updated the post title text styles, and moved the search bar to the new position shown in the designs. 

Depends on https://github.com/WordPress/wporg-mu-plugins/pull/624 and https://github.com/WordPress/wporg-parent-2021/pull/140
Closes https://github.com/WordPress/wporg-documentation-2022/issues/96
Closes https://github.com/WordPress/wporg-documentation-2022/issues/95

### Screenshots

#### Desktop

| Before | After |
|--------|-------|
| ![wordpress org_documentation_article_search-engine-optimization_(Desktop)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/52655a63-08f7-4ab9-a755-132270178772) | ![wordpress org_documentation_article_search-engine-optimization_(Desktop) (1)](https://github.com/WordPress/wporg-documentation-2022/assets/1017872/4890bf25-e685-43a7-8688-47deecf1ce3b) |

### How to test the changes in this Pull Request:

1. Easiest to test in sandbox along with the [sibling PR for Developer Resources](https://github.com/WordPress/wporg-developer/pull/522)
2. Check the position of the table of content on page load and when scrolling. Check that the height of the sidebar reduces when coming in contact with the tall footer. Check responsive behaviour.
5. Check the search bar position across the site