### PR TITLE
layout: fix embedded video overflow causing horizontal scroll

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -47,27 +47,25 @@ body.page .wp-block-wporg-local-navigation-bar .wp-block-query-title {
 
 /* Fix: Prevent horizontal scroll and ensure embedded media is responsive */
 .entry-content {
-  overflow-x: hidden; /* scope to article content only */
+	overflow-x: hidden; /* scope to article content only */
 
-  .wp-block-video,
-  .wp-block-embed {
-    max-width: 100%;
-  }
+	.wp-block-video,
+	.wp-block-embed {
+		max-width: 100%;
+	}
 
-  .wp-block-video video,
-  .wp-block-embed__wrapper iframe,
-  .wp-block-embed embed,
-  .wp-block-embed object {
-    display: block;
-    max-width: 100%;
-    width: 100%;
-    height: auto;
-  }
+	.wp-block-video video,
+	.wp-block-embed__wrapper iframe,
+	.wp-block-embed embed,
+	.wp-block-embed object {
+		display: block;
+		max-width: 100%;
+		width: 100%;
+		height: auto;
+	}
 
-  figure.wp-block-video,
-  figure.wp-block-embed {
-    max-width: 100%;
-  }
+	figure.wp-block-video,
+	figure.wp-block-embed {
+		max-width: 100%;
+	}
 }
-
-

--- a/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-documentation-2022/src/style/style.scss
@@ -43,3 +43,31 @@ body.page .wp-block-wporg-local-navigation-bar .wp-block-query-title {
 		outline-offset: 1.5px;
 	}
 }
+
+
+/* Fix: Prevent horizontal scroll and ensure embedded media is responsive */
+.entry-content {
+  overflow-x: hidden; /* scope to article content only */
+
+  .wp-block-video,
+  .wp-block-embed {
+    max-width: 100%;
+  }
+
+  .wp-block-video video,
+  .wp-block-embed__wrapper iframe,
+  .wp-block-embed embed,
+  .wp-block-embed object {
+    display: block;
+    max-width: 100%;
+    width: 100%;
+    height: auto;
+  }
+
+  figure.wp-block-video,
+  figure.wp-block-embed {
+    max-width: 100%;
+  }
+}
+
+


### PR DESCRIPTION
**What**
- Constrain `.wp-block-video` / `.wp-block-embed` and their inner media to the content column.
- Make videos/embeds responsive (max-width:100%; height:auto).
- Scope overflow handling to `.entry-content` (avoid masking legit wide elements site-wide).

**Why**
- On https://wordpress.org/documentation/article/block-error-unexpected-or-invalid-content/
  the embedded video exceeds the column, causing horizontal scrolling and header/TOC misalignment.

**How to test**
1) Build the theme (`yarn workspace wporg-docs-2022-theme build`) and view the article around 1024px width.
2) Confirm no horizontal scroll.
3) Header and right “In this article” TOC stay aligned.
4) Video scales within the content column.

**Screenshots**
Before:
<img width="1910" height="950" alt="Screenshot 2025-08-19 170014" src="https://github.com/user-attachments/assets/84baf630-8a0b-4f9e-8da1-8e6756a0e1b3" />

here see the responsiveness :

<img width="1917" height="962" alt="Screenshot 2025-08-19 170048" src="https://github.com/user-attachments/assets/fc47f9c1-8034-4522-8768-b39c21524530" />

After :

<img width="1913" height="913" alt="image" src="https://github.com/user-attachments/assets/409ddb30-512f-49d6-9882-7aa4943f1b92" />


Note: This PR does not alter the example “invalid content” inside the article (that’s intentional for demonstration). It only fixes the surrounding layout so embeds remain responsive and don’t cause horizontal scrolling.