### PR TITLE
docs(admin-bar): hide “Edit Site” on Documentation (Fixes #101)

### DIFF
--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -22,11 +22,19 @@ add_filter( 'render_block_core/term-description', __NAMESPACE__ . '\inject_term_
 add_filter( 'jetpack_open_graph_tags', __NAMESPACE__ . '\custom_open_graph_tags' );
 add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
 
-add_action( 'admin_bar_menu', __NAMESPACE__ . '\\hide_site_editor_node', 999 );
-function hide_site_editor_node( \WP_Admin_Bar $bar ) : void {
+// Hide edit Site from the admin bar (Site Editor entry point).
+add_action( 'admin_bar_menu', __NAMESPACE__ . '\hide_site_editor_node', 999 );
+
+/**
+ * Remove the Site Editor admin-bar item on the docs site.
+ *
+ * Keeps editors in the page editor workflow.
+ *
+ * @param WP_Admin_Bar $bar Admin Bar instance.
+ */
+function hide_site_editor_node( $bar ) {
 	$bar->remove_node( 'site-editor' );
 }
-
 // Enable Jetpack opengraph by default
 add_filter( 'jetpack_enable_open_graph', '__return_true' );
 

--- a/source/wp-content/themes/wporg-documentation-2022/functions.php
+++ b/source/wp-content/themes/wporg-documentation-2022/functions.php
@@ -22,6 +22,11 @@ add_filter( 'render_block_core/term-description', __NAMESPACE__ . '\inject_term_
 add_filter( 'jetpack_open_graph_tags', __NAMESPACE__ . '\custom_open_graph_tags' );
 add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
 
+add_action( 'admin_bar_menu', __NAMESPACE__ . '\\hide_site_editor_node', 999 );
+function hide_site_editor_node( \WP_Admin_Bar $bar ) : void {
+	$bar->remove_node( 'site-editor' );
+}
+
 // Enable Jetpack opengraph by default
 add_filter( 'jetpack_enable_open_graph', '__return_true' );
 


### PR DESCRIPTION
**Summary**
Docs should be edited as Pages. The admin-bar **Edit Site** link opens the Site Editor and allows template-level changes (header/footer). This removes that entry point.

**Change**
Remove toolbar node `site-editor` via `admin_bar_menu` (priority 999) in:
`source/wp-content/themes/wporg-documentation-2022/functions.php`.

**How to test**
1) Log in and view any docs page.
2) Toolbar no longer shows **Edit Site**; **Edit** still opens the page editor.

Fixes #101
