### PR TITLE
Redirect WordPress version 6.8.4 (unreleased) to WordPress 6.8.5.

### DIFF
--- a/source/wp-content/mu-plugins/site-documentation.php
+++ b/source/wp-content/mu-plugins/site-documentation.php
@@ -48,8 +48,9 @@ function redirect_old_content() {
 		'/documentation/category/customizing/' => '/documentation/customization/',
 		'/documentation/category/basic-usage/' => '/documentation/support-guides/',
 
-		// WordPress release that never was.
+		// WordPress releases that never were.
 		'/documentation/wordpress-version/version-6-5-1/' => '/documentation/wordpress-version/version-6-5-2/',
+		'/documentation/wordpress-version/version-6-8-4/' => '/documentation/wordpress-version/version-6-8-5/',
 
 		// Redirect articles to Advanced Administration handbook on devhub.
 		'/documentation/article/administration-over-ssl/'                           => 'https://developer.wordpress.org/advanced-administration/security/https/',


### PR DESCRIPTION
While WordPress 6.8.4 was tagged, it was never released. 

This adds a PHP site redirect to the docs site so the redirect can take place. I hacked the permalink/slug to introduce the redirect via querying the meta key but adding this in code will be more efficient.



<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #, See #.

<!-- List out anyone who helped with this task. -->
Props <username>, <username>

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Before | After |
|--------|-------|
| image  | image |

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate [Component] label(s). -->
